### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "A CLI tool that provides AI-powered analysis and suggestions for 
 license = "MIT"
 readme = "README.md"
 authors = ["Suraj Singh <surajssc1232@gmail.com>"]
-homepage = "https://github.com/surajssc1232/wut_rust"
+repository = "https://github.com/surajssc1232/wut_rust"
 exclude = ["pkg/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
According to the [manifest](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91